### PR TITLE
Fix 'Could not resolve all files for configuration ':[projectname]:implementationDependenciesMetadata'

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -28,7 +28,7 @@ dependencies {
 group = 'net.idlestate'
 archivesBaseName = 'gradle-download-dependencies-plugin'
 // Please comply with the rules of Semantic Versioning (http://semver.org) and tag releases.
-version = '1.4.3'
+version = '1.4.4'
 
 task sourceJar( type: Jar ) {
     from sourceSets.main.allGroovy

--- a/src/main/groovy/net/idlestate/gradle/downloaddependencies/DownloadDependenciesTask.groovy
+++ b/src/main/groovy/net/idlestate/gradle/downloaddependencies/DownloadDependenciesTask.groovy
@@ -62,7 +62,6 @@ class DownloadDependenciesTask extends DefaultTask {
                         }
                     }
                 )
-
                 configuration.incoming.files.each { file ->
                     libraryFiles[ file.name ] = file
                 }
@@ -95,10 +94,17 @@ class DownloadDependenciesTask extends DefaultTask {
      * we have to check before accessing it.
      */
     boolean isConfigurationResolvable( configuration ) {
-        if ( !configuration.metaClass.respondsTo( configuration, 'isCanBeResolved' ) ) {
-            // If the recently introduced method 'isCanBeResolved' is unavailable, we
-            // assume (for now) that the configuration can be resolved.
+        // The recently introduced method 'isCanBeResolved' may be unavailable
+        def hasCanBeResolved = configuration.metaClass.respondsTo( configuration, 'isCanBeResolved' )
+        // Assume (for now) that configurations without 'isCanBeResolved' can be resolved.
+        if ( !hasCanBeResolved ) {
             return true
+        }
+
+        // DependenciesMetadata-Configrations may not be resolved directly but do not implement 'isCanBeResolved' correctly
+        def isDependenciesMetadataConfig = configuration.name.endsWith("DependenciesMetadata")
+        if ( isDependenciesMetadataConfig ) {
+            return false
         }
 
         return configuration.isCanBeResolved()


### PR DESCRIPTION
Using the api/implementation dependency configurations with kotlin
creates additional configurations like
'implementationDependenciesMetadata'.
Those should not be resolved directly but don't implement
isCanBeResolved correctly.